### PR TITLE
add uninit_com, enable init_com again

### DIFF
--- a/TexconvDLL/texassemble.cpp
+++ b/TexconvDLL/texassemble.cpp
@@ -1058,15 +1058,20 @@ namespace
 static int texassemble_base(int argc, wchar_t* argv[], bool verbose, bool init_com, wchar_t* err_buf, int err_buf_size);
 extern "C" __declspec(dllexport) int __cdecl texassemble(int argc, wchar_t* argv[], bool verbose = true, bool init_com = false, wchar_t* err_buf = nullptr, int err_buf_size = 0)
 {
+    HRESULT hr = S_OK;
+
     // Initialize COM
-    HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE)
-    {
-        RaiseError(L"Failed to initialize COM (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
-        return 1;
+    if (init_com) {
+        hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+        if (FAILED(hr) && hr != RPC_E_CHANGED_MODE)
+        {
+            RaiseError(L"Failed to initialize COM (%08X%ls)\n", static_cast<unsigned int>(hr), GetErrorDesc(hr));
+            return 1;
+        }
     }
     int ret = texassemble_base(argc, argv, verbose, init_com, err_buf, err_buf_size);
-    CoUninitialize();
+    if (init_com && hr != RPC_E_CHANGED_MODE)
+        CoUninitialize();
     return ret;
 }
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -62,14 +62,38 @@ int texassemble(int argc, wchar_t* argv[], bool verbose = true,
 
 -   `argc`: The number of arguments for texassemble.
 -   `argv`: An array of arguments for texassemble.
--   `verbose`: Show info
--   `init_com`: This flag was used for old versions. It does nothing.
+-   `verbose`: Shows info
+-   `init_com`: Calls init_com() and uninit_com() internally.
 -   `err_buf`: A buffer to store error messages.
 -   `err_buf_size`: The size of the buffer.
 
 The return value is the execution status.  
 0 means no errors.  
 And 1 means failed to convert.  
+
+#### init_com
+
+```c++
+int init_com()
+```
+
+On Windows, you should initialize [COM](https://learn.microsoft.com/en-us/windows/win32/com/the-component-object-model) once in a process.  
+This function provides a way to do.  
+It will do nothing on Unix/Linux systems.  
+
+The return value is the same as [CoInitializeEx](https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-coinitializeex)'s one.  
+0 means "Initialized."  
+1 means "It is already initialized."  
+-2147417850 means "It is already initialized with single thread mode."  
+
+#### uninit_com
+
+```c++
+void uninit_com()
+```
+
+If `init_com()` returns 0 or 1, you should uninitialize COM with this function after executing your program.  
+It will do nothing on Unix/Linux systems.  
 
 ### Example for Python
 
@@ -94,8 +118,17 @@ argv = (ctypes.c_wchar_p*len(argv))(*argv)
 err_buf = ctypes.create_unicode_buffer(512)
 
 # Convert DDS to TGA
+result = dll.texconv(len(argv), argv, verbose=True, init_com=True, allow_slow_codec=False,
+                     err_buf=err_buf, err_buf_size=512)
+
+"""
+# You can also initialize COM by yourself.
+initialized = dll.init_com()
 result = dll.texconv(len(argv), argv, verbose=True, init_com=False, allow_slow_codec=False,
                      err_buf=err_buf, err_buf_size=512)
+if initialized == 0 or initialized == 1:
+    dll.uninit_com()
+"""
 
 # Show error message
 if result != 0:


### PR DESCRIPTION
I noticed that #9 crashed when calling texconv() multipletimes with multiprocessing.
So, I reverted the behavior of `init_com` flag and function.
I also added `uninit_com()` to call `CoUninitialize()`.

Calling `texconv()` with `init_com=1` works in most cases.
If it crashes, call `init_com()` and `uninit_com()` by yourself.

### Example
```python
# init_com=True calls init_com() and uninit_com() internally.
result = dll.texconv(len(argv), argv, verbose=True, init_com=True, allow_slow_codec=False,
                     err_buf=err_buf, err_buf_size=512)

# You can also initialize COM by yourself.
initialized = dll.init_com()
result = dll.texconv(len(argv), argv, verbose=True, init_com=False, allow_slow_codec=False,
                     err_buf=err_buf, err_buf_size=512)
if initialized == 0 or initialized == 1:
    dll.uninit_com()
```