### PR TITLE
revert a change for MAX_PATH

### DIFF
--- a/TexconvDLL/tool_util.h
+++ b/TexconvDLL/tool_util.h
@@ -21,14 +21,10 @@ extern "C"{
 // wcsicmp for Windows = wcscasecmp for Unix
 #define _wcsicmp wcscasecmp
 
-// replace MAX_PATH with PATH_MAX for unix
-#ifdef PATH_MAX
-#define MAX_PATH PATH_MAX
-#else  // PATH_MAX
+// TODO: replace MAX_PATH with PATH_MAX for linux?
 #ifndef MAX_PATH
 #define MAX_PATH 260
 #endif
-#endif  // PATH_MAX
 
 // Todo: define _wcslwr_s for unix
 // (for USE_NAME_CONFIG)


### PR DESCRIPTION
I noticed texconv used MAX_PATH for stack allocations. So PATH_MAX was too large for it.
It should use 260 as MAX_PATH again.