### PR TITLE
Remove locale settings from DLL

### DIFF
--- a/TexconvDLL/texassemble.cpp
+++ b/TexconvDLL/texassemble.cpp
@@ -1107,9 +1107,6 @@ extern "C" __attribute__((visibility("default"))) int texassemble(int argc, wcha
 
     std::wstring outputFile;
 
-    // Set locale for output since GetErrorDesc can get localized strings.
-    std::locale::global(std::locale(""));
-
     HRESULT hr = S_OK;
 
     // Process command line
@@ -2908,6 +2905,9 @@ extern "C" __attribute__((visibility("default"))) int texassemble(int argc, wcha
 #ifdef _WIN32
 int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 {
+    // Set locale for output since GetErrorDesc can get localized strings.
+    std::locale::global(std::locale(""));
+
     bool verbose = true;
     bool init_com = true;
 #else

--- a/TexconvDLL/texconv.cpp
+++ b/TexconvDLL/texconv.cpp
@@ -1579,9 +1579,6 @@ extern "C" __attribute__((visibility("default"))) int texconv(int argc, wchar_t*
     wchar_t szSuffix[MAX_PATH] = {};
     std::filesystem::path outputDir;
 
-    // Set locale for output since GetErrorDesc can get localized strings.
-    std::locale::global(std::locale(""));
-
     HRESULT hr = S_OK;
 
     // Process command line
@@ -4226,6 +4223,9 @@ extern "C" __attribute__((visibility("default"))) int texconv(int argc, wchar_t*
 #ifdef _WIN32
 int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 {
+    // Set locale for output since GetErrorDesc can get localized strings.
+    std::locale::global(std::locale(""));
+
     bool verbose = true;
     bool init_com = true;
 #else

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v0.4.2
+- Fixed a bug that DLL functions change locale settings.
+
 v0.4.1
 - Updated DirectXTex to June2024 release.
 - Added uninit_com()

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Texconv-Custom-DLL v0.4.1
+# Texconv-Custom-DLL v0.4.2
 
 Cross-platform implementation for [Texconv](https://github.com/microsoft/DirectXTex/wiki/Texconv) and [Texassemble](https://github.com/Microsoft/DirectXTex/wiki/Texassemble).  
 And you can use it as a DLL (or a shared library).  


### PR DESCRIPTION
Related to #14.
It is undesirable for DLLs to change the locale. texconv.dll should use the callers' locale.