### PR TITLE
Fix and improve workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.github
+.gitignore
+batch_files
+build
+build_exe
+docs

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -77,21 +77,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ needs.setup.outputs.tag }} release/${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}.zip
 
-  build_unix:
+  build_macos:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
         use_libs: [false, true]
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     needs: setup
     steps:
       - uses: actions/checkout@v4
       - run: |
           git submodule update --init --recursive --recommend-shallow --depth 1
-
-      - name: Install requirements
-        if: (runner.os == 'Linux') && matrix.use_libs
-        run: sudo apt-get update && sudo apt-get install -y libjpeg-dev libpng-dev
 
       - name: build texconv
         if: matrix.use_libs == false
@@ -115,6 +110,38 @@ jobs:
           cp LICENSE release/${{ env.ZIP_NAME }}
           cd release
           tar -jcvf ${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2 ${{ env.ZIP_NAME }}
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ needs.setup.outputs.tag }} release/${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2
+
+  build_linux:
+    strategy:
+      matrix:
+        use_libs: [false, true]
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          git submodule update --init --recursive --recommend-shallow --depth 1
+
+      - name: build texconv
+        run: |
+          docker build --build-arg JPGPNG=${{ matrix.use_libs }} -t texconv -f Dockerfile_Ubuntu ./
+
+      - name: Copy files
+        run: |
+          mkdir -p release/${{ env.ZIP_NAME }}
+          docker run --name texconv texconv
+          docker cp texconv:/Texconv-Custom-DLL/libtexconv.so ./release/${{ env.ZIP_NAME }}
+          docker cp texconv:/Texconv-Custom-DLL/texconv ./release/${{ env.ZIP_NAME }}
+          docker cp texconv:/Texconv-Custom-DLL/texassemble ./release/${{ env.ZIP_NAME }}
+          cp changelog.txt release/${{ env.ZIP_NAME }}
+          cp LICENSE release/${{ env.ZIP_NAME }}
+          cd release
+          tar -jcvf ${{ env.ZIP_NAME }}-${{ runner.os }}${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2 ${{ env.ZIP_NAME }}
 
       - name: Upload Release Asset
         env:

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -69,13 +69,13 @@ jobs:
         with:
           directory: 'release'
           type: 'zip'
-          filename: '${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}.zip'
+          filename: '${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-x64.zip'
           exclusions: '*.git* .gitignore'
 
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ needs.setup.outputs.tag }} release/${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}.zip
+        run: gh release upload ${{ needs.setup.outputs.tag }} release/${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-x64.zip
 
   build_macos:
     strategy:
@@ -109,12 +109,12 @@ jobs:
           cp changelog.txt release/${{ env.ZIP_NAME }}
           cp LICENSE release/${{ env.ZIP_NAME }}
           cd release
-          tar -jcvf ${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2 ${{ env.ZIP_NAME }}
+          tar -jcvf ${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-arm64${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2 ${{ env.ZIP_NAME }}
 
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ needs.setup.outputs.tag }} release/${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2
+        run: gh release upload ${{ needs.setup.outputs.tag }} release/${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-arm64${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2
 
   build_linux:
     strategy:
@@ -141,9 +141,9 @@ jobs:
           cp changelog.txt release/${{ env.ZIP_NAME }}
           cp LICENSE release/${{ env.ZIP_NAME }}
           cd release
-          tar -jcvf ${{ env.ZIP_NAME }}-${{ runner.os }}${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2 ${{ env.ZIP_NAME }}
+          tar -jcvf ${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-x64${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2 ${{ env.ZIP_NAME }}
 
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ needs.setup.outputs.tag }} release/${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2
+        run: gh release upload ${{ needs.setup.outputs.tag }} release/${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-x64${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -43,7 +43,7 @@ jobs:
           prerelease: false
 
   build_windows:
-    runs-on: windows-2022
+    runs-on: windows-latest
     needs: setup
     steps:
       - uses: actions/checkout@v4
@@ -80,15 +80,18 @@ jobs:
   build_unix:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-latest, macos-latest]
         use_libs: [false, true]
     runs-on: ${{ matrix.os }}
     needs: setup
     steps:
       - uses: actions/checkout@v4
       - run: |
-          git submodule update --init --recursive
-          bash shell_scripts/get_sal.sh
+          git submodule update --init --recursive --recommend-shallow --depth 1
+
+      - name: Install requirements
+        if: (runner.os == 'Linux') && matrix.use_libs
+        run: sudo apt-get update && sudo apt-get install -y libjpeg-dev libpng-dev
 
       - name: build texconv
         if: matrix.use_libs == false

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -12,12 +12,11 @@ jobs:
     strategy:
       matrix:
         use_libs: [false, true]
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - run: |
-          git submodule update --init --recursive
-          bash shell_scripts/get_sal.sh
+          git submodule update --init --recursive --recommend-shallow --depth 1
 
       - name: build texconv
         if: matrix.use_libs == false

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -39,7 +39,7 @@ jobs:
           cp changelog.txt release/${{ env.ZIP_NAME }}
           cp LICENSE release/${{ env.ZIP_NAME }}
           cd release
-          tar -jcvf ${{ env.ZIP_NAME }}-${{ runner.os }}${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2 ${{ env.ZIP_NAME }}
+          tar -jcvf ${{ env.ZIP_NAME }}-${{ runner.os }}-arm64${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2 ${{ env.ZIP_NAME }}
 
       - name: Create Release Draft
         id: create-release
@@ -57,4 +57,4 @@ jobs:
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref }} release/${{ env.ZIP_NAME }}-${{ runner.os }}${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2
+        run: gh release upload ${{ github.ref }} release/${{ env.ZIP_NAME }}-${{ runner.os }}-arm64${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -18,28 +18,17 @@ jobs:
       - run: |
           git submodule update --init --recursive --recommend-shallow --depth 1
 
-      - name: Install requirements
-        if: matrix.use_libs
-        run: sudo apt-get update && sudo apt-get install -y libjpeg-dev libpng-dev
-
       - name: build texconv
-        if: matrix.use_libs == false
         run: |
-          bash shell_scripts/build.sh
-          bash shell_scripts/build_as_exe.sh
-
-      - name: build texconv with libjpeg and libpng
-        if: matrix.use_libs == true
-        run: |
-          bash shell_scripts/build_with_jpg_png.sh
-          bash shell_scripts/build_as_exe_with_jpg_png.sh
+          docker build --build-arg JPGPNG=${{ matrix.use_libs }} -t texconv -f Dockerfile_Ubuntu ./
 
       - name: Copy files
         run: |
           mkdir -p release/${{ env.ZIP_NAME }}
-          cp libtexconv.so release/${{ env.ZIP_NAME }}
-          cp texconv release/${{ env.ZIP_NAME }}
-          cp texassemble release/${{ env.ZIP_NAME }}
+          docker run --name texconv texconv
+          docker cp texconv:/Texconv-Custom-DLL/libtexconv.so ./release/${{ env.ZIP_NAME }}
+          docker cp texconv:/Texconv-Custom-DLL/texconv ./release/${{ env.ZIP_NAME }}
+          docker cp texconv:/Texconv-Custom-DLL/texassemble ./release/${{ env.ZIP_NAME }}
           cp changelog.txt release/${{ env.ZIP_NAME }}
           cp LICENSE release/${{ env.ZIP_NAME }}
           cd release

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -32,7 +32,7 @@ jobs:
           cp changelog.txt release/${{ env.ZIP_NAME }}
           cp LICENSE release/${{ env.ZIP_NAME }}
           cd release
-          tar -jcvf ${{ env.ZIP_NAME }}-${{ runner.os }}${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2 ${{ env.ZIP_NAME }}
+          tar -jcvf ${{ env.ZIP_NAME }}-${{ runner.os }}-x64${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2 ${{ env.ZIP_NAME }}
 
       - name: Create Release Draft
         id: create-release
@@ -50,4 +50,4 @@ jobs:
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref }} release/${{ env.ZIP_NAME }}-${{ runner.os }}${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2
+        run: gh release upload ${{ github.ref }} release/${{ env.ZIP_NAME }}-${{ runner.os }}-x64${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -12,12 +12,15 @@ jobs:
     strategy:
       matrix:
         use_libs: [false, true]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: |
-          git submodule update --init --recursive
-          bash shell_scripts/get_sal.sh
+          git submodule update --init --recursive --recommend-shallow --depth 1
+
+      - name: Install requirements
+        if: matrix.use_libs
+        run: sudo apt-get update && sudo apt-get install -y libjpeg-dev libpng-dev
 
       - name: build texconv
         if: matrix.use_libs == false
@@ -34,7 +37,7 @@ jobs:
       - name: Copy files
         run: |
           mkdir -p release/${{ env.ZIP_NAME }}
-          cp libtexconv.dylib release/${{ env.ZIP_NAME }}
+          cp libtexconv.so release/${{ env.ZIP_NAME }}
           cp texconv release/${{ env.ZIP_NAME }}
           cp texassemble release/${{ env.ZIP_NAME }}
           cp changelog.txt release/${{ env.ZIP_NAME }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           directory: 'release'
           type: 'zip'
-          filename: '${{ env.ZIP_NAME }}-${{ runner.os }}.zip'
+          filename: '${{ env.ZIP_NAME }}-${{ runner.os }}-x64.zip'
           exclusions: '*.git* .gitignore'
 
       - name: Create Release Draft
@@ -53,4 +53,4 @@ jobs:
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref }} release/${{ env.ZIP_NAME }}-${{ runner.os }}.zip
+        run: gh release upload ${{ github.ref }} release/${{ env.ZIP_NAME }}-${{ runner.os }}-x64.zip

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
       - run: git submodule update --init --recursive DirectXTex

--- a/Dockerfile_Alpine
+++ b/Dockerfile_Alpine
@@ -3,7 +3,7 @@
 # 1. Use this docker file to build the executable.
 #    docker build -t texconv -f Dockerfile_Alpine ./
 #
-# 2. Run the built image. 
+# 2. Run the built image.
 #    docker run texconv
 #
 # 3. Use "docker cp" to get the built executables.
@@ -12,21 +12,35 @@
 #
 # 4. Also, you can get the built shared library.
 #    docker cp <CONTAINER ID>:/Texconv-Custom-DLL/libtexconv.so ./
+#
+# Notes:
+#   -You can add JPEG and PNG support with build-arg
+#    docker build --build-arg JPGPNG=true -t texconv -f Dockerfile_Alpine ./
 
 # Base image
-ARG alpine_version="3.16.3"
-FROM alpine:${alpine_version}
+FROM matyalatte/alpine3.16-cmake3.25:latest
+
+# Add JPEG and PNG support when true
+ARG JPGPNG=false
 
 # Install packages
-RUN apk update &&\
-    apk add --no-cache musl-dev gcc make g++ file alpine-sdk cmake wget bash
+RUN apk update && \
+    apk add --no-cache musl-dev gcc make g++ file alpine-sdk cmake wget bash && \
+    if [ "$JPGPNG" = "true" ]; then \
+        apk add --no-cache libjpeg-turbo-dev libpng-dev; \
+    fi
 
 # Clone repo
-RUN git clone --recursive --depth=1 https://github.com/matyalatte/Texconv-Custom-DLL.git
+COPY . /Texconv-Custom-DLL
+WORKDIR /Texconv-Custom-DLL
+RUN git submodule update --init --recursive --recommend-shallow --depth 1
 
-# Build shared lib
+# Build
 WORKDIR /Texconv-Custom-DLL/shell_scripts
-RUN bash build.sh
-
-# Build executable
-RUN bash build_as_exe.sh
+RUN if [ "$JPGPNG" = "true" ]; then \
+        bash build_with_jpg_png.sh && \
+        bash build_as_exe_with_jpg_png.sh; \
+    else \
+        bash build.sh && \
+        bash build_as_exe.sh; \
+    fi

--- a/Dockerfile_Alpine
+++ b/Dockerfile_Alpine
@@ -22,8 +22,7 @@ RUN apk update &&\
     apk add --no-cache musl-dev gcc make g++ file alpine-sdk cmake wget bash
 
 # Clone repo
-RUN git clone --recursive --depth=1 https://github.com/matyalatte/Texconv-Custom-DLL.git;\
-    bash Texconv-Custom-DLL/shell_scripts/get_sal.sh
+RUN git clone --recursive --depth=1 https://github.com/matyalatte/Texconv-Custom-DLL.git
 
 # Build shared lib
 WORKDIR /Texconv-Custom-DLL/shell_scripts

--- a/Dockerfile_Ubuntu
+++ b/Dockerfile_Ubuntu
@@ -12,25 +12,39 @@
 #
 # 4. Also, you can get the built shared library.
 #    docker cp <CONTAINER ID>:/Texconv-Custom-DLL/libtexconv.so ./
+#
+# Notes:
+#   -You can add JPEG and PNG support with build-arg
+#    docker build --build-arg JPGPNG=true -t texconv -f Dockerfile_Ubuntu ./
 
 # Base image
-ARG ubuntu_version="20.04"
-FROM ubuntu:${ubuntu_version}
+FROM matyalatte/ubuntu20.04-cmake3.25:latest
+
+# Add JPEG and PNG support when true
+ARG JPGPNG=false
 
 # Install packages
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       wget ca-certificates build-essential git cmake \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        wget ca-certificates build-essential git cmake && \
+    if [ "$JPGPNG" = "true" ]; then \
+        apt-get install -y --no-install-recommends libjpeg-dev libpng-dev; \
+    fi && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Clone repo
-RUN git clone --recursive --depth=1 https://github.com/matyalatte/Texconv-Custom-DLL.git
+COPY . /Texconv-Custom-DLL
+WORKDIR /Texconv-Custom-DLL
+RUN git submodule update --init --recursive --recommend-shallow --depth 1
 
-# Build shared lib
+# Build
 WORKDIR /Texconv-Custom-DLL/shell_scripts
-RUN bash build.sh
-
-# Build executable
-RUN bash build_as_exe.sh
+RUN if [ "$JPGPNG" = "true" ]; then \
+        bash build_with_jpg_png.sh && \
+        bash build_as_exe_with_jpg_png.sh; \
+    else \
+        bash build.sh && \
+        bash build_as_exe.sh; \
+    fi

--- a/Dockerfile_Ubuntu
+++ b/Dockerfile_Ubuntu
@@ -26,8 +26,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Clone repo
-RUN git clone --recursive --depth=1 https://github.com/matyalatte/Texconv-Custom-DLL.git;\
-    bash Texconv-Custom-DLL/shell_scripts/get_sal.sh
+RUN git clone --recursive --depth=1 https://github.com/matyalatte/Texconv-Custom-DLL.git
 
 # Build shared lib
 WORKDIR /Texconv-Custom-DLL/shell_scripts

--- a/TexconvDLL/config.h.in
+++ b/TexconvDLL/config.h.in
@@ -6,12 +6,6 @@
 #define __ON__ 1
 #define __OFF__ 0
 
-#ifdef _WIN32
-#define IS_WIN32 1
-#else
-#define IS_WIN32 0
-#endif
-
 #define BUILD_AS_EXE __@TEXCONV_BUILD_AS_EXE@__
 
 //--------------------------------------------------------------------------------------
@@ -24,17 +18,15 @@
 // Printing
 //--------------------------------------------------------------------------------------
 // Use -timing or not
-#define USE_TIMING IS_WIN32
+#define USE_TIMING (defined(_WIN32))
 
 //--------------------------------------------------------------------------------------
 // Options
 //--------------------------------------------------------------------------------------
-#define USE_WILDCARD IS_WIN32
+#define USE_WILDCARD (defined(_WIN32))
 
 // Disable GPU codec for BC6 and BC7
 #define NO_GPU_CODEC __@TEXCONV_NO_GPU_CODEC@__
 
 // Use texassemble as a dll function
 #define USE_TEXASSEMBLE __@TEXCONV_USE_TEXASSEMBLE@__
-
-#undef IS_WIN32

--- a/TexconvDLL/config.h.in
+++ b/TexconvDLL/config.h.in
@@ -23,22 +23,13 @@
 //--------------------------------------------------------------------------------------
 // Printing
 //--------------------------------------------------------------------------------------
-// Use PrintLogo() or not
-#define USE_LOGO 0
-
 // Use -timing or not
 #define USE_TIMING IS_WIN32
-
-// Use PrintInfo and PrintFormat
-#define USE_PRINT_INFO 1
 
 //--------------------------------------------------------------------------------------
 // Options
 //--------------------------------------------------------------------------------------
 #define USE_WILDCARD IS_WIN32
-
-// Use -px, -sx, and -l
-#define USE_NAME_CONFIG IS_WIN32
 
 // Disable GPU codec for BC6 and BC7
 #define NO_GPU_CODEC __@TEXCONV_NO_GPU_CODEC@__

--- a/TexconvDLL/config.h.in
+++ b/TexconvDLL/config.h.in
@@ -14,16 +14,18 @@
 // Use non-DDS formats (bmp, jpg, png, jxr, etc.) or not
 #define USE_WIC __@TEXCONV_USE_WIC@__
 
-//--------------------------------------------------------------------------------------
-// Printing
-//--------------------------------------------------------------------------------------
-// Use -timing or not
-#define USE_TIMING (defined(_WIN32))
+#ifdef _WIN32
 
-//--------------------------------------------------------------------------------------
-// Options
-//--------------------------------------------------------------------------------------
-#define USE_WILDCARD (defined(_WIN32))
+// Use -timing or not
+#define USE_TIMING 1
+
+// Use wildcard in paths or not
+#define USE_WILDCARD 1
+
+#else  // _WIN32
+#define USE_TIMING 0
+#define USE_WILDCARD 0
+#endif  // _WIN32
 
 // Disable GPU codec for BC6 and BC7
 #define NO_GPU_CODEC __@TEXCONV_NO_GPU_CODEC@__

--- a/TexconvDLL/texassemble.cpp
+++ b/TexconvDLL/texassemble.cpp
@@ -2342,11 +2342,7 @@ extern "C" __attribute__((visibility("default"))) int texassemble(int argc, wcha
 
             if (~dwOptions & (1 << OPT_OVERWRITE))
             {
-            #ifdef _WIN32
-                if (GetFileAttributesW(outputFile.c_str()) != INVALID_FILE_ATTRIBUTES)
-            #else
-                if (std::filesystem::exists(outputFile.c_str()))
-            #endif
+                if (std::filesystem::exists(outputFile))
                 {
                     RaiseError(L"\nERROR: Output file already exists, use -y to overwrite\n");
                     return 1;
@@ -2414,11 +2410,7 @@ extern "C" __attribute__((visibility("default"))) int texassemble(int argc, wcha
 
             if (~dwOptions & (1 << OPT_OVERWRITE))
             {
-            #ifdef _WIN32
-                if (GetFileAttributesW(outputFile.c_str()) != INVALID_FILE_ATTRIBUTES)
-            #else
-                if (std::filesystem::exists(outputFile.c_str()))
-            #endif
+                if (std::filesystem::exists(outputFile))
                 {
                     RaiseError(L"\nERROR: Output file already exists, use -y to overwrite\n");
                     return 1;
@@ -2487,11 +2479,7 @@ extern "C" __attribute__((visibility("default"))) int texassemble(int argc, wcha
 
             if (~dwOptions & (1 << OPT_OVERWRITE))
             {
-            #ifdef _WIN32
-                if (GetFileAttributesW(outputFile.c_str()) != INVALID_FILE_ATTRIBUTES)
-            #else
-                if (std::filesystem::exists(outputFile.c_str()))
-            #endif
+                if (std::filesystem::exists(outputFile))
                 {
                     RaiseError(L"\nERROR: Output file already exists, use -y to overwrite\n");
                     return 1;
@@ -2695,11 +2683,7 @@ extern "C" __attribute__((visibility("default"))) int texassemble(int argc, wcha
 
             if (~dwOptions & (1 << OPT_OVERWRITE))
             {
-            #ifdef _WIN32
-                if (GetFileAttributesW(outputFile.c_str()) != INVALID_FILE_ATTRIBUTES)
-            #else
-                if (std::filesystem::exists(outputFile.c_str()))
-            #endif
+                if (std::filesystem::exists(outputFile))
                 {
                     RaiseError(L"\nERROR: Output file already exists, use -y to overwrite\n");
                     return 1;
@@ -2757,11 +2741,7 @@ extern "C" __attribute__((visibility("default"))) int texassemble(int argc, wcha
 
             if (~dwOptions & (1 << OPT_OVERWRITE))
             {
-            #ifdef _WIN32
-                if (GetFileAttributesW(outputFile.c_str()) != INVALID_FILE_ATTRIBUTES)
-            #else
-                if (std::filesystem::exists(outputFile.c_str()))
-            #endif
+                if (std::filesystem::exists(outputFile))
                 {
                     RaiseError(L"\nERROR: Output file already exists, use -y to overwrite\n");
                     return 1;
@@ -2874,11 +2854,7 @@ extern "C" __attribute__((visibility("default"))) int texassemble(int argc, wcha
 
             if (~dwOptions & (1 << OPT_OVERWRITE))
             {
-            #ifdef _WIN32
-                if (GetFileAttributesW(outputFile.c_str()) != INVALID_FILE_ATTRIBUTES)
-            #else
-                if (std::filesystem::exists(outputFile.c_str()))
-            #endif
+                if (std::filesystem::exists(outputFile))
                 {
                     RaiseError(L"\nERROR: Output file already exists, use -y to overwrite\n");
                     return 1;

--- a/TexconvDLL/texconv.cpp
+++ b/TexconvDLL/texconv.cpp
@@ -3972,24 +3972,13 @@ extern "C" __attribute__((visibility("default"))) int texconv(int argc, wchar_t*
                     continue;
                 }
 
-            #ifdef _WIN32
-                auto const err = static_cast<DWORD>(SHCreateDirectoryExW(nullptr, apath.c_str(), nullptr));
-                if (err != ERROR_SUCCESS && err != ERROR_ALREADY_EXISTS)
-                {
-                    RaiseError(L" directory creation FAILED (%08X%ls)\n",
-                        static_cast<unsigned int>(HRESULT_FROM_WIN32(err)), GetErrorDesc(HRESULT_FROM_WIN32(err)));
-                    retVal = 1;
-                    continue;
-                }
-            #else
-                std::filesystem::create_directory(apath, ec);
+                std::filesystem::create_directories(apath, ec);
                 if (ec)
                 {
                     RaiseError(L" directory creation FAILED (%hs)\n", ec.message().c_str());
                     retVal = 1;
                     continue;
                 }
-            #endif
             }
 
             if (*szPrefix)
@@ -4016,11 +4005,7 @@ extern "C" __attribute__((visibility("default"))) int texconv(int argc, wchar_t*
 
             if (~dwOptions & (uint64_t(1) << OPT_OVERWRITE))
             {
-            #ifdef _WIN32
-                if (GetFileAttributesW(destName.c_str()) != INVALID_FILE_ATTRIBUTES)
-            #else
-                if (std::filesystem::exists(destName.c_str()))
-            #endif
+                if (std::filesystem::exists(destName))
                 {
                     RaiseError(L"\nERROR:Output file already exists, use -y to overwrite:\n");
                     retVal = 1;

--- a/TexconvDLL/tool_util.h
+++ b/TexconvDLL/tool_util.h
@@ -10,10 +10,6 @@ extern "C"{
 }
 #include <filesystem>
 
-//#define S_OK 0
-//#define E_FAIL 0x80004005
-//#define FAILED(hr) hr != S_OK
-
 // Todo: Use secure function
 #define swscanf_s swscanf
 #define swprintf_s swprintf
@@ -29,105 +25,7 @@ extern "C"{
 // Todo: define _wcslwr_s for unix
 // (for USE_NAME_CONFIG)
 
-// wmakepath_s for unix
-template <size_t size>
-void _wmakepath_s(
-   wchar_t (&path)[size],
-   const wchar_t *drv,
-   const wchar_t *dir,
-   const wchar_t *fname,
-   const wchar_t *ext
-) {
-    wchar_t* end = &path[0] + size;    /* end of path buffer */
-    wchar_t* s = &path[0];      /* copy pointer */
-    if (drv) {
-        for(;*drv && *drv != '\0' && s < end;)
-            *s++ = *drv++;
-    }
-    if (dir) {
-        for(;*dir && *dir!= '\0' && s < end;)
-            *s++ = *dir++;
-    }
-    if (s > &path[0] && s < end && (*(s - 1) != std::filesystem::path::preferred_separator)) {
-        *s++ = std::filesystem::path::preferred_separator;
-    }
-    if (fname) {
-        for(; *fname && *fname!= '\0' && s < end;)
-            *s++ = *fname++;
-    }
-    if (s < end) {
-        *s++ = '.';
-    }
-    if (ext) {
-        for(; *ext && *ext!= '\0' && s < end;)
-            *s++ = *ext++;
-    }
-    if (s < end) {
-        *s = '\0';
-    }
-}
-
-// wsplitpath_s for unix
-static void _wsplitpath_s(const WCHAR* path, WCHAR* drv, int drvnum, WCHAR* dir, int dirnum, WCHAR* name, int namenum, WCHAR* ext, int extnum)
-{
-    const WCHAR* end; /* end of processed string */
-    const WCHAR* p;      /* search pointer */
-    const WCHAR* s;      /* copy pointer */
-
-    /* extract drive name */
-    if (path[0] && path[1]==':') {
-            if (drv) {
-                    *drv++ = *path++;
-                    *drv++ = *path++;
-                    *drv = '\0';
-            }
-    } else if (drv)
-            *drv = '\0';
-
-    /* search for end of string or stream separator */
-    for(end=path; *end && *end!=':'; )
-            end++;
-
-
-    /* search for begin of file extension */
-    for(p=end; p>path && *--p!='\\' && *p!='/'; )
-            if (*p == '.') {
-                    end = p;
-                    break;
-            }
-
-    if (ext)
-            for(s=end; (*ext=*s++); )
-                    ext++;
-
-    /* search for end of directory name */
-    for(p=end; p>path; )
-            if (*--p=='\\' || *p=='/') {
-                    p++;
-                    break;
-            }
-
-    if (name) {
-            for(s=p; s<end; )
-                    *name++ = *s++;
-
-            *name = '\0';
-    }
-
-    if (dir) {
-            for(s=path; s<p; )
-                    *dir++ = *s++;
-
-            *dir = '\0';
-    }
-}
-#endif
-
-#ifdef _WIN32
-#define ErrorIsMissingPath(hr) hr == -2147024893;
-#else
-#define ErrorIsMissingPath(hr) hr == -2147467259;
-#endif
+#endif  // _WIN32
 
 #define RaiseError(...) \
     fwprintf(stderr, __VA_ARGS__); \

--- a/docs/Build-on-Unix.md
+++ b/docs/Build-on-Unix.md
@@ -1,55 +1,46 @@
 # Building Workflow for Linux and MacOS
 
-You can build texconv on Linux and macOS.  
-But please note that there are some limitations.  
+You can build texconv on Linux and macOS.
+However, please note that there are some limitations.  
 
 -   Unable to use GPU for conversion.
 -   Unable to use WIC supported formats (`.bmp`, `.jpg`, `.png`, etc.)
     (Or requires libjpeg and libpng to support `.jpg` and `.png`.)
 
-Also, the offical Texconv only supports Windows.  
-I made sure I can build it with the following platforms and compilers.  
-But it might not work on your environment.  
+Also, the offical Texconv only supports Windows. I made sure I could build it with the following platforms and compilers but it might not work on your environment.  
 
 -   Ubuntu 20.04 + GCC 9.4
 -   MacOS 11 + AppleClang 13.0
 
 ## 0. Requirements
 
-- xcode (for macOS)
-- build-essential (for Linux)
+- c++17 compiler
 - cmake
-- wget
+- git
+- bash
 
 ## 1. Get submodules
 
-Move to `./Texconv-Custom-DLL`.  
-Then, type `git submodule update --init --recursive`.  
-It'll install DirectX related files on the repository.
+Move to `./Texconv-Custom-DLL` and run `git submodule update --init --recursive`.  
+It downloads DirectX related files on the repository.
 
-## 2. Get sal.h
-
-On non-Windows platform, DirectXMath requires [sal.h](https://github.com/dotnet/corert/blob/master/src/Native/inc/unix/sal.h).  
-Move to `./Texconv-Custom-DLL/shell_scripts` and type `bash get_sal.sh`.  
-It will put the file into `./Texconv-Custom-DLL/unix_external/sal/`.  
-
-## 3. Build the binary with a shell script
+## 2. Build the binary with a shell script
 
 You can build `libtexconv.so` (or `libtexconv.dylib`) with a shell script.  
 Run `bash shell_scripts/build.sh` on the terminal.  
 (Or run `bash shell_scripts/build_with_jpg_png.sh` to support `.jpg` and `.png`.)  
-`libtexconv.so` (or `libtexconv.dylib`) will be generated in `./Texconv-Custom-DLL/`.  
+It generates `libtexconv.so` (or `libtexconv.dylib`) in `./Texconv-Custom-DLL/`.  
 
-## 4. Build executables (optional)
+## 3. Build executables (optional)
 
 If you want an executable, use `build_as_exe.sh` instead of `build.sh`.  
 (Or use `build_as_exe_with_jpg_png.sh` to support `.jpg` and `.png`.)  
-`texconv` and `texassemble` will be generated in `./Texconv-Custom-DLL/`.  
+It generates `texconv` and `texassemble` in `./Texconv-Custom-DLL/`.  
 You can use them on the terminal. (e.g. `./texconv -ft tga -y -o outdir test.dds`)  
 
-## 5. Build universal binary on macOS (optional)
+## 4. Build universal binary on macOS (optional)
 
 `build_universal.sh` can build universal binary.  
 The built shared library works on both of x64 and arm64 chips.  
 Also, you might be able to add `ENABLE_LIBJPEG_SUPPORT=ON` and `ENABLE_LIBPNG_SUPPORT=ON` to cmake options to support jpeg and png.  
-But they should require arm64 version of libjpeg and libpng.
+But they should require universal binaries of libjpeg and libpng.

--- a/docs/Build-on-Windows.md
+++ b/docs/Build-on-Windows.md
@@ -4,17 +4,18 @@
 
 -   Visual Studio 2022
 -   CMake
+-   git
 
 ## 1. Get DirectXTex
 Move to `./Texconv-Custom-DLL` and type `git submodule update --init --recursive DirectXTex`.  
-It'll download DirectXTex to the repository.  
-(`git submodule update --init --recursive` will work as well, but it'll download unnecessary repositories for Windows.)  
+It downloads DirectXTex to the repository.  
+(`git submodule update --init --recursive` works as well, but it downloads unnecessary repositories for Windows.)  
 
 ## 2-a. Build .dll with batch files
 
 You can build texconv.dll with batch files.  
 Move to `./Texconv-Custom-DLL/batch_files` and type `build.bat` on the command prompt.  
-`texconv.dll` will be generated in `Texconv-Custom-DLL/`.  
+It generates `texconv.dll` in `Texconv-Custom-DLL/`.  
 
 ## 2-b. Build .dll with Visual Studio
 
@@ -25,10 +26,10 @@ Then, you can build texconv.dll.
 ## 3. Build executables (optional)
 
 If you want executables, use `build_as_exe.bat` instead of `build.bat`.  
-`texconv.exe` and `texassemble.exe` will be generated in `./Texconv-Custom-DLL/`.  
+It generates `texconv.exe` and `texassemble.exe` in `./Texconv-Custom-DLL/`.  
 You can use them on the command prompt. (e.g. `texconv.exe -ft tga -y -o outdir test.dds`)  
 
 ## 4. Build .dll with dynamic linked runtime (optional)
 
 If your app can access to `vcruntime140.dll`, you can use `build_without_vcruntime.bat` to link the dynamic vcruntime to `texconv.dll`.  
-The binary size will be about 500KB smaller than the static linked dll.
+The binary size is about 500KB smaller than the static linked dll.

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,19 +29,18 @@ But the custom build supports the following platforms and compilers.
 
 ## Download
 
-You can download the built binary from [the release page](https://github.com/matyalatte/Texconv-Custom-DLL/releases).  
+You can download built binaries from [the release page](https://github.com/matyalatte/Texconv-Custom-DLL/releases).  
+Each zip file has a DLL and executables. The executables don't refer the DLL.
 
 -   `TexconvCustomDLL*-Windows.zip` is for Windows.
 -   `TexconvCustomDLL*-macOS.tar.bz2` is for macOS (10.15 or later).
 -   `TexconvCustomDLL*-Linux.tar.bz2` is for Linux with GLIBC 2.27+ and GLIBCXX 3.4.26+.
 
-> Each zip file has a DLL and executables.  
-> You can copy whichever you want to use to your project.  
-> (The executables don't refer the DLL.)
-
+> [!Note]
 > Linux and macOS builds requrie libjpeg and libpng.  
 > Or use `*-no-deps.tar.bz2` versions that don't support jpg and png.
 
+> [!Note]
 > The linux build only supports distributions using GLIBC.  
 > Build the executable by yourself if you want to use it on unsupported distros.
 

--- a/shell_scripts/get_sal.sh
+++ b/shell_scripts/get_sal.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# Download sal.h for DirectXMath
-
-cd $(dirname "$0")/../unix_external
-mkdir sal
-cd sal
-wget https://raw.githubusercontent.com/dotnet/corert/master/src/Native/inc/unix/sal.h

--- a/unix_external/CMakeLists.txt
+++ b/unix_external/CMakeLists.txt
@@ -4,13 +4,20 @@ cmake_minimum_required (VERSION 3.14)
 # DirectX-Headers
 add_library(DirectX-Headers INTERFACE)
 target_include_directories(DirectX-Headers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/DirectX-Headers/include)
-if (NOT WIN32)
-    target_include_directories(DirectX-Headers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/DirectX-Headers/include/wsl/stubs)
-endif()
+target_include_directories(DirectX-Headers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/DirectX-Headers/include/wsl/stubs)
 add_library(Microsoft::DirectX-Headers ALIAS DirectX-Headers)
 
+# Download sal.h
+set(SAL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/sal)
+file(MAKE_DIRECTORY ${SAL_DIR})
+file(DOWNLOAD
+    https://raw.githubusercontent.com/dotnet/corert/master/src/Native/inc/unix/sal.h
+    ${SAL_DIR}/sal.h
+    SHOW_PROGRESS
+    EXPECTED_HASH SHA256=bb9ea7c1d05cdfc10a17fe80d87a7cd160c1063c7e5fa089cd6405c31c610a1b
+)
+
 # DirectXMath
-# it needs sal.h in Texconv-Custom-DLL/unix_external/sal/ (https://github.com/dotnet/corert/blob/master/src/Native/inc/unix/sal.h)
 add_library(DirectXMath INTERFACE)
 target_include_directories(DirectXMath INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/DirectXMath/Inc


### PR DESCRIPTION
This PR includes some fixes and improvements for building workflows. I can now start to upgrade submodules.

- Upgraded Github hosted runners to fix workflows.
- Github Actions now use docker for Linux builds.
- CMake can now download `sal.h`. (You don't need to run `get_sal.sh` manually.)
- Removed unused macros and functions from header files.
- Revised documents.