### PR TITLE
make shell scripts executable

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -98,14 +98,14 @@ jobs:
       - name: build texconv
         if: matrix.use_libs == false
         run: |
-          bash shell_scripts/build.sh
-          bash shell_scripts/build_as_exe.sh
+          ./shell_scripts/build.sh
+          ./shell_scripts/build_as_exe.sh
 
       - name: build texconv with libjpeg and libpng
         if: matrix.use_libs == true
         run: |
-          bash shell_scripts/build_with_jpg_png.sh
-          bash shell_scripts/build_as_exe_with_jpg_png.sh
+          ./shell_scripts/build_with_jpg_png.sh
+          ./shell_scripts/build_as_exe_with_jpg_png.sh
 
       - name: Copy files
         run: |

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -21,14 +21,14 @@ jobs:
       - name: build texconv
         if: matrix.use_libs == false
         run: |
-          bash shell_scripts/build.sh
-          bash shell_scripts/build_as_exe.sh
+          ./shell_scripts/build.sh
+          ./shell_scripts/build_as_exe.sh
 
       - name: build texconv with libjpeg and libpng
         if: matrix.use_libs == true
         run: |
-          bash shell_scripts/build_with_jpg_png.sh
-          bash shell_scripts/build_as_exe_with_jpg_png.sh
+          ./shell_scripts/build_with_jpg_png.sh
+          ./shell_scripts/build_as_exe_with_jpg_png.sh
 
       - name: Copy files
         run: |

--- a/Dockerfile_Alpine
+++ b/Dockerfile_Alpine
@@ -25,7 +25,7 @@ ARG JPGPNG=false
 
 # Install packages
 RUN apk update && \
-    apk add --no-cache musl-dev gcc make g++ file alpine-sdk cmake wget bash && \
+    apk add --no-cache musl-dev gcc make g++ file alpine-sdk wget bash && \
     if [ "$JPGPNG" = "true" ]; then \
         apk add --no-cache libjpeg-turbo-dev libpng-dev; \
     fi
@@ -38,9 +38,9 @@ RUN git submodule update --init --recursive --recommend-shallow --depth 1
 # Build
 WORKDIR /Texconv-Custom-DLL/shell_scripts
 RUN if [ "$JPGPNG" = "true" ]; then \
-        bash build_with_jpg_png.sh && \
-        bash build_as_exe_with_jpg_png.sh; \
+        ./build_with_jpg_png.sh && \
+        ./build_as_exe_with_jpg_png.sh; \
     else \
-        bash build.sh && \
-        bash build_as_exe.sh; \
+        ./build.sh && \
+        ./build_as_exe.sh; \
     fi

--- a/Dockerfile_Ubuntu
+++ b/Dockerfile_Ubuntu
@@ -27,7 +27,7 @@ ARG JPGPNG=false
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        wget ca-certificates build-essential git cmake && \
+        wget ca-certificates build-essential git && \
     if [ "$JPGPNG" = "true" ]; then \
         apt-get install -y --no-install-recommends libjpeg-dev libpng-dev; \
     fi && \
@@ -42,9 +42,9 @@ RUN git submodule update --init --recursive --recommend-shallow --depth 1
 # Build
 WORKDIR /Texconv-Custom-DLL/shell_scripts
 RUN if [ "$JPGPNG" = "true" ]; then \
-        bash build_with_jpg_png.sh && \
-        bash build_as_exe_with_jpg_png.sh; \
+        ./build_with_jpg_png.sh && \
+        ./build_as_exe_with_jpg_png.sh; \
     else \
-        bash build.sh && \
-        bash build_as_exe.sh; \
+        ./build.sh && \
+        ./build_as_exe.sh; \
     fi

--- a/docs/Build-on-Unix.md
+++ b/docs/Build-on-Unix.md
@@ -27,8 +27,8 @@ It downloads DirectX related files on the repository.
 ## 2. Build the binary with a shell script
 
 You can build `libtexconv.so` (or `libtexconv.dylib`) with a shell script.  
-Run `bash shell_scripts/build.sh` on the terminal.  
-(Or run `bash shell_scripts/build_with_jpg_png.sh` to support `.jpg` and `.png`.)  
+Run `./shell_scripts/build.sh` on the terminal.  
+(Or run `./shell_scripts/build_with_jpg_png.sh` to support `.jpg` and `.png`.)  
 It generates `libtexconv.so` (or `libtexconv.dylib`) in `./Texconv-Custom-DLL/`.  
 
 ## 3. Build executables (optional)

--- a/shell_scripts/build.sh
+++ b/shell_scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Builds texconv with cmake.
 # libtexconv.so or libtexconv.dylib will be generated in ./Texconv-Custom-DLL/
 

--- a/shell_scripts/build_as_exe.sh
+++ b/shell_scripts/build_as_exe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Builds executables with cmake.
 # texconv and texassemble will be generated in ./Texconv-Custom-DLL/
 

--- a/shell_scripts/build_as_exe_with_jpg_png.sh
+++ b/shell_scripts/build_as_exe_with_jpg_png.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Builds executables with cmake.
 # texconv and texassemble will be generated in ./Texconv-Custom-DLL/
 

--- a/shell_scripts/build_universal.sh
+++ b/shell_scripts/build_universal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Builds texconv with cmake.
 # libtexconv.so or libtexconv.dylib will be generated in ./Texconv-Custom-DLL/
 

--- a/shell_scripts/build_with_jpg_png.sh
+++ b/shell_scripts/build_with_jpg_png.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Builds texconv with cmake.
 # libtexconv.so or libtexconv.dylib will be generated in ./Texconv-Custom-DLL/
 


### PR DESCRIPTION
You can now run shell scripts as executables without the `bash` command.