### PR TITLE
Add THIRD_PARTY_LICENSES.txt

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -69,6 +69,7 @@ jobs:
           cp texassemble.exe release/
           cp changelog.txt release/
           cp LICENSE release/
+          cp THIRD_PARTY_LICENSES.txt release/
         shell: bash
 
       - name: Archive Release
@@ -106,6 +107,7 @@ jobs:
           cp texassemble release/${{ env.ZIP_NAME }}
           cp changelog.txt release/${{ env.ZIP_NAME }}
           cp LICENSE release/${{ env.ZIP_NAME }}
+          cp THIRD_PARTY_LICENSES.txt release/${{ env.ZIP_NAME }}
           cd release
           tar -jcvf ${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-arm64.tar.bz2 ${{ env.ZIP_NAME }}
 
@@ -135,6 +137,7 @@ jobs:
           docker cp texconv:/Texconv-Custom-DLL/texassemble ./release/${{ env.ZIP_NAME }}
           cp changelog.txt release/${{ env.ZIP_NAME }}
           cp LICENSE release/${{ env.ZIP_NAME }}
+          cp THIRD_PARTY_LICENSES.txt release/${{ env.ZIP_NAME }}
           cd release
           tar -jcvf ${{ env.ZIP_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-x64.tar.bz2 ${{ env.ZIP_NAME }}
 

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -39,6 +39,7 @@ jobs:
           cp texassemble release/${{ env.ZIP_NAME }}
           cp changelog.txt release/${{ env.ZIP_NAME }}
           cp LICENSE release/${{ env.ZIP_NAME }}
+          cp THIRD_PARTY_LICENSES.txt release/${{ env.ZIP_NAME }}
           cd release
           tar -jcvf ${{ env.ZIP_NAME }}-${{ runner.os }}-arm64${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2 ${{ env.ZIP_NAME }}
 

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -31,6 +31,7 @@ jobs:
           docker cp texconv:/Texconv-Custom-DLL/texassemble ./release/${{ env.ZIP_NAME }}
           cp changelog.txt release/${{ env.ZIP_NAME }}
           cp LICENSE release/${{ env.ZIP_NAME }}
+          cp THIRD_PARTY_LICENSES.txt release/${{ env.ZIP_NAME }}
           cd release
           tar -jcvf ${{ env.ZIP_NAME }}-${{ runner.os }}-x64${{ ((matrix.use_libs == false) && '-no-deps') || '' }}.tar.bz2 ${{ env.ZIP_NAME }}
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -34,6 +34,7 @@ jobs:
           cp texassemble.exe release/
           cp changelog.txt release/
           cp LICENSE release/
+          cp THIRD_PARTY_LICENSES.txt release/
         shell: bash
 
       - name: Archive Release

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ out
 *.dds
 *.tga
 *.png
+*.jpg
 
 # script
 *.bat

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1,0 +1,142 @@
+Third-Party Licenses
+
+This software includes third-party libraries.
+This software is based in part on the work of the Independent JPEG Group.
+The following licenses apply to the respective components.
+
+==================================================
+MIT License
+==================================================
+
+The following projects are licensed under the MIT License:
+
+- DirectXTex
+  Copyright (c) Microsoft Corporation.
+  URL: https://github.com/microsoft/DirectXTex
+- DirectX-Headers
+  Copyright (c) Microsoft Corporation.
+  URL: https://github.com/microsoft/DirectX-Headers
+- DirectXMath
+  Copyright (c) Microsoft Corporation.
+  URL: https://github.com/microsoft/DirectXMath
+- safestringlib (only included in Linux/macOS binaries)
+  Copyright (c) 2014-2018 Intel Corporation
+  URL: https://github.com/intel/safestringlib
+
+----- MIT License Text -----
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=======================================================
+zlib/libpng License
+=======================================================
+
+The following projects are licensed under the zlib/libpng License:
+
+- libpng (only included in Linux/macOS binaries)
+  * Copyright (c) 1995-2025 The PNG Reference Library Authors.
+  * Copyright (c) 2018-2025 Cosmin Truta.
+  * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
+  * Copyright (c) 1996-1997 Andreas Dilger.
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+  URL: https://github.com/pnggroup/libpng
+
+- zlib (only included in Linux binaries)
+  (C) 1995-2025 Jean-loup Gailly and Mark Adler
+  URL: https://github.com/madler/zlib.git
+
+- SIMD extension for libjpeg-turbo (only included in Linux/macOS binaries)
+  Copyright (C) 1999-2006, MIYASAKA Masaru.
+  and more libjpeg-turbo contributors. (Individual contributors are listed in the source files)
+  URL: https://github.com/libjpeg-turbo/libjpeg-turbo
+
+----- zlib/libpng License Text -----
+
+The software is supplied "as is", without warranty of any kind,
+express or implied, including, without limitation, the warranties
+of merchantability, fitness for a particular purpose, title, and
+non-infringement.  In no event shall the Copyright owners, or
+anyone distributing the software, be liable for any damages or
+other liability, whether in contract, tort or otherwise, arising
+from, out of, or in connection with the software, or the use or
+other dealings in the software, even if advised of the possibility
+of such damage.
+
+Permission is hereby granted to use, copy, modify, and distribute
+this software, or portions hereof, for any purpose, without fee,
+subject to the following restrictions:
+
+ 1. The origin of this software must not be misrepresented; you
+    must not claim that you wrote the original software.  If you
+    use this software in a product, an acknowledgment in the product
+    documentation would be appreciated, but is not required.
+
+ 2. Altered source versions must be plainly marked as such, and must
+    not be misrepresented as being the original software.
+
+ 3. This Copyright notice may not be removed or altered from any
+    source or altered source distribution.
+
+
+==============================================================
+IJG (Independent JPEG Group) License
+==============================================================
+
+The following project is licensed under the zlib/libpng License:
+
+- libjpeg API library for libjpeg-turbo (only included in Linux/macOS binaries)
+  URL: https://github.com/libjpeg-turbo/libjpeg-turbo
+
+----- IJG License Text -----
+
+The authors make NO WARRANTY or representation, either express or implied,
+with respect to this software, its quality, accuracy, merchantability, or
+fitness for a particular purpose.  This software is provided "AS IS", and you,
+its user, assume the entire risk as to its quality and accuracy.
+
+This software is copyright (C) 1991-2020, Thomas G. Lane, Guido Vollbeding.
+All Rights Reserved except as specified below.
+
+Permission is hereby granted to use, copy, modify, and distribute this
+software (or portions thereof) for any purpose, without fee, subject to these
+conditions:
+(1) If any part of the source code for this software is distributed, then this
+README file must be included, with this copyright and no-warranty notice
+unaltered; and any additions, deletions, or changes to the original files
+must be clearly indicated in accompanying documentation.
+(2) If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the work of
+the Independent JPEG Group".
+(3) Permission for use of this software is granted only if the user accepts
+full responsibility for any undesirable consequences; the authors accept
+NO LIABILITY for damages of any kind.
+
+These conditions apply to any software derived from or based on the IJG code,
+not just to the unmodified library.  If you use our work, you ought to
+acknowledge us.
+
+Permission is NOT granted for the use of any IJG author's name or company name
+in advertising or publicity relating to this software or products derived from
+it.  This software may be referred to only as "the Independent JPEG Group's
+software".
+
+We specifically permit and encourage the use of this software as the basis of
+commercial products, provided that all warranty or liability claims are
+assumed by the product vendor.

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,5 +68,27 @@ See the files for the details.
 - [Dockerfile_Ubuntu](../Dockerfile_Ubuntu): Build texconv with GCC and glibc on Ubuntu
 - [Dockerfile_Alpine](../Dockerfile_Alpine): Build texconv with GCC and musl on Alpine Linux
 
-## License
-Files in this repository (including all submodules) are licensed under [MIT license](../LICENSE).
+## Licenses
+
+The original source code of this repository is licensed
+under the MIT License (see [LICENSE](../LICENSE)).
+
+This project includes third-party software, which is licensed under its own
+respective licenses. When redistributing binaries, you must retain
+[THIRD_PARTY_LICENSES.txt](./THIRD_PARTY_LICENSES.txt) to comply with those
+licenses.
+
+See [THIRD_PARTY_LICENSES.txt](./THIRD_PARTY_LICENSES.txt) for full license texts
+and copyright notices.
+
+### Third-party components
+
+| Project | License | Included in |
+|--------|--------|-------------|
+| [DirectXTex](https://github.com/microsoft/DirectXTex) | MIT License | All platforms |
+| [DirectX-Headers](https://github.com/microsoft/DirectX-Headers) | MIT License | All platforms |
+| [DirectXMath](https://github.com/microsoft/DirectXMath) | MIT License | All platforms |
+| [safestringlib](https://github.com/intel/safestringlib) | MIT License | Linux / macOS |
+| [libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo) | zlib/libpng License, IJG License | Linux / macOS |
+| [libpng](https://github.com/pnggroup/libpng) | zlib/libpng License | Linux / macOS |
+| [zlib](https://github.com/madler/zlib.git) | zlib/libpng License | Linux |


### PR DESCRIPTION
Just including `./LICENSE` in packages violates third-party licenses even when they use the MIT license. I added `THIRD_PARTY_LICENSES.txt` to fix the license issue.
(While legal issues rarely arise in practice, it's better to fix them.) 