### PR TITLE
add a polyglot script: build.cmd

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -57,8 +57,8 @@ jobs:
 
       - name: build exe
         run: |
-          batch_files/build.bat --use-optional-formats
-          batch_files/build.bat --use-optional-formats --build-as-exe
+          .\build.cmd --use-optional-formats
+          .\build.cmd --use-optional-formats --build-as-exe
 
       - name: Copy files
         run: |
@@ -103,8 +103,8 @@ jobs:
       - name: build texconv
         run: |
           brew install nasm
-          ./shell_scripts/build.sh --use-optional-formats ${{ matrix.flag }}
-          ./shell_scripts/build.sh --use-optional-formats --build-as-exe  ${{ matrix.flag }}
+          ./build.cmd --use-optional-formats ${{ matrix.flag }}
+          ./build.cmd --use-optional-formats --build-as-exe  ${{ matrix.flag }}
 
       - name: Copy files
         run: |

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -21,15 +21,15 @@ jobs:
       - name: build texconv
         if: matrix.use_libs == false
         run: |
-          ./shell_scripts/build.sh --universal
-          ./shell_scripts/build.sh --universal --build-as-exe
+          ./build.cmd --universal
+          ./build.cmd --universal --build-as-exe
 
       - name: build texconv with libjpeg and libpng
         if: matrix.use_libs == true
         run: |
           brew install nasm
-          ./shell_scripts/build.sh --universal --use-optional-formats
-          ./shell_scripts/build.sh --universal --use-optional-formats --build-as-exe
+          ./build.cmd --universal --use-optional-formats
+          ./build.cmd --universal --use-optional-formats --build-as-exe
 
       - name: Copy files
         run: |

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: build exe
         run: |
-          batch_files/build.bat --use-optional-formats
-          batch_files/build.bat --use-optional-formats --build-as-exe
+          .\build.cmd --use-optional-formats
+          .\build.cmd --use-optional-formats --build-as-exe
 
       - name: Copy files
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_windows:
+  test:
     strategy:
       matrix:
         include:
@@ -16,25 +16,19 @@ jobs:
             arch: x64
           - os: windows-11-arm
             arch: arm64
+          - os: macos-latest
+            arch: ""
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - run: git submodule update --init --recursive DirectXTex
+      - run: git submodule update --init --recursive --recommend-shallow --depth 1
+
+      - name: install nasm
+        if: runner.os == 'macOS'
+        run: brew install nasm
 
       - name: build and run tests
-        run: batch_files/test.bat
-
-  test_macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: |
-          git submodule update --init --recursive --recommend-shallow --depth 1
-
-      - name: build texconv
-        run: |
-          brew install nasm
-          ./shell_scripts/test.sh
+        run: ./build.cmd --test
 
   test_linux:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(APPLE)
 endif()
 
 include(GNUInstallDirs)
-include("options.cmake")
+include("cmake/options.cmake")
 
 #--- Third Party Libraries
 if(TEXCONV_USE_STATIC_LINK)

--- a/Dockerfile_Alpine
+++ b/Dockerfile_Alpine
@@ -39,12 +39,11 @@ WORKDIR /Texconv-Custom-DLL
 RUN git submodule update --init --recursive --recommend-shallow --depth 1
 
 # Build
-WORKDIR /Texconv-Custom-DLL/shell_scripts
 RUN if [ "$TEST" = "true" ]; then \
-        ./test.sh && \
-        ./build.sh --use-optional-formats --build-as-exe; \
+        ./build.cmd --test && \
+        ./build.cmd --use-optional-formats --build-as-exe; \
     else \
         OPT=$([ "$JPGPNG" = "true" ] && echo "--use-optional-formats") && \
-        ./build.sh $OPT && \
-        ./build.sh $OPT --build-as-exe; \
+        ./build.cmd $OPT && \
+        ./build.cmd $OPT --build-as-exe; \
     fi

--- a/Dockerfile_Ubuntu
+++ b/Dockerfile_Ubuntu
@@ -43,12 +43,11 @@ WORKDIR /Texconv-Custom-DLL
 RUN git submodule update --init --recursive --recommend-shallow --depth 1
 
 # Build
-WORKDIR /Texconv-Custom-DLL/shell_scripts
 RUN if [ "$TEST" = "true" ]; then \
-        ./test.sh && \
-        ./build.sh --use-optional-formats --build-as-exe; \
+        ./build.cmd --test && \
+        ./build.cmd --use-optional-formats --build-as-exe; \
     else \
         OPT=$([ "$JPGPNG" = "true" ] && echo "--use-optional-formats") && \
-        ./build.sh $OPT && \
-        ./build.sh $OPT --build-as-exe; \
+        ./build.cmd $OPT && \
+        ./build.cmd $OPT --build-as-exe; \
     fi

--- a/batch_files/build.bat
+++ b/batch_files/build.bat
@@ -33,6 +33,7 @@ set BUILD_AS_EXE=OFF
 set VCRUNTIME=MultiThreaded
 set USE_WIC=ON
 set USE_EXR=OFF
+set USE_STATIC=ON
 set USE_TEXASSEMBLE=ON
 set TEST=OFF
 
@@ -63,6 +64,10 @@ if "%~1"=="--debug" (
     set USE_EXR=ON
 ) else if "%~1"=="--use-optional-formats" (
     set USE_EXR=ON
+) else if "%~1"=="--use-dynamic-link" (
+    set USE_STATIC=OFF
+) else if "%~1"=="--universal" (
+    echo Warning: --universal is only available on macOS
 ) else if "%~1"=="--help" (
     goto usage
 ) else (
@@ -88,7 +93,7 @@ set CMAKE_OPTIONS=-G "%GENERATOR%"^
  -DTEXCONV_BUILD_TESTS=%TEST%^
  -DTEXCONV_USE_WIC=%USE_WIC%^
  -DTEXCONV_USE_TEXASSEMBLE=%USE_TEXASSEMBLE%^
- -DTEXCONV_USE_STATIC_LINK=ON^
+ -DTEXCONV_USE_STATIC_LINK=%USE_STATIC%^
  -DENABLE_OPENEXR_SUPPORT=%USE_EXR%
 
 mkdir %SCRIPT_DIR%\..\%BUILD_DIR%
@@ -115,22 +120,25 @@ if "%BUILD_AS_EXE%"=="ON" (
 exit /b 0
 
 :usage
-echo Usage: build.bat ^<options^>
-echo   --build-as-exe    build texconv and texassemble as executables
-echo   --runtime-dll     use dynamic linked vcruntime
-echo   --debug           enable debug build
-echo   --test            build and run tests
-echo   --no-wic          disable WIC supported formats (JPEG, PNG, etc.)
-echo   --no-texassemble  do not build texassemble
-echo   --use-exr         support EXR format
-echo   --use-optional-formats  same as --use-exr
-echo   --generator       one of CMake Generators e.g. Visual Studio 17 2022
+echo Usage: build.cmd ^[options^]
+echo   --build-as-exe          build texconv and texassemble as executables
+echo   --use-optional-formats  support EXR format
+echo   --use-dynamic-link      use system installed OpenEXR
+echo   --no-texassemble        do not build texassemble
+echo   --debug                 enable debug build
+echo   --test                  build and run tests
+echo   --generator ^<name^>      specify a build system e.g. Ninja
+echo   --runtime-dll           use dynamic linked vcruntime
+echo   --no-wic                disable WIC supported formats (JPEG, PNG, etc.)
+echo   --use-exr               same as --use-optional-formats
 echo.
 echo   Examples:
-echo     build.bat
+echo     build.cmd
 echo       generates texconv.dll in the project root (Texconv-Custom-DLL/)
-echo     build.bat --build-as-exe
+echo     build.cmd --build-as-exe
 echo       generates texconv.exe and texassemble.exe in the project root.
-echo     build.bat --build-as-exe --generator "MinGW Makefiles"
+echo     build.cmd --use-optional-formats
+echo       generates texconv.dll with EXR support
+echo     build.cmd --build-as-exe --generator "MinGW Makefiles"
 echo       builds texconv.exe with MinGW's make
 exit /b 0

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,10 @@
+:<<'END'
+@echo off
+rem build.cmd works as a batch file on Windows.
+%~dp0\batch_files\build.bat %*
+goto :eof
+END
+
+# build.cmd works as a shell script on Linux/macOS.
+#!/usr/bin/env bash
+$(dirname "$0")/shell_scripts/build.sh "$@" || exit 1

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -33,6 +33,14 @@ if(TEXCONV_BUILD_TESTS AND TEXCONV_BUILD_AS_EXE)
   message(FATAL_ERROR "You can NOT build both tests and executables at the same time.")
 endif()
 
+if(TEXCONV_BUILD_TESTS)
+  set(ENABLE_OPENEXR_SUPPORT ON)
+  if(NOT WIN32)
+    set(ENABLE_LIBJPEG_SUPPORT ON)
+    set(ENABLE_LIBPNG_SUPPORT ON)
+  endif()
+endif()
+
 # enable all options
 if(TEXCONV_USE_ALL)
   set(TEXCONV_USE_WIC ON)

--- a/docs/Build-on-Unix.md
+++ b/docs/Build-on-Unix.md
@@ -6,11 +6,6 @@ However, please note that there are some limitations.
 -   Unable to use GPU for conversion.
 -   Unable to use WIC supported formats (e.g. `.bmp`) except for `.jpg` and `.png`.
 
-Also, the offical Texconv only supports Windows. I made sure I could build it with the following platforms and compilers but it might not work on your environment.  
-
--   Ubuntu 20.04 + GCC 9.4
--   MacOS 11 + AppleClang 13.0
-
 ## 0. Requirements
 
 - c++17 compiler
@@ -21,20 +16,18 @@ Also, the offical Texconv only supports Windows. I made sure I could build it wi
 
 ## 1. Get submodules
 
-Move to `./Texconv-Custom-DLL` and run `git submodule update --init --recursive`.
+Move to `./Texconv-Custom-DLL` and get submodules.
 
 ```
 git submodule update --init --recursive
 ```
 
-It downloads DirectX related files on the repository.
-
 ## 2. Build the binary
 
-You can build `libtexconv.so` (or `libtexconv.dylib`) with `./shell_scripts/build.sh`.
+You can build `libtexconv.so` (or `libtexconv.dylib`) with `./build.cmd`.
 
 ```
-./shell_scripts/build.sh --use-optional-formats
+./build.cmd --use-optional-formats
 ```
 
 It generates `libtexconv.so` (or `libtexconv.dylib`) in `./Texconv-Custom-DLL/`.  
@@ -44,7 +37,7 @@ It generates `libtexconv.so` (or `libtexconv.dylib`) in `./Texconv-Custom-DLL/`.
 If you want executables, add `--build-as-exe` to options.
 
 ```
-./shell_scripts/build.sh --use-optional-formats --build-as-exe
+./build.cmd --use-optional-formats --build-as-exe
 ```
 
 It generates `texconv` and `texassemble` in `./Texconv-Custom-DLL/`.  
@@ -52,26 +45,27 @@ You can use the built binaries on the terminal. (e.g. `./texconv -ft tga -y -o o
 
 ## 4. More options
 
-There are more options for `build.sh`.
+There are more options for `build.cmd`.
 
 ```console
-> ./shell_scripts/build.sh --help
-Usage: build.sh <options>
+> ./build.cmd --help
+Usage: build.cmd [options]
   --build-as-exe          build texconv and texassemble as executables
-  --use-optional-formats  use 3rd party libraries to support non-DDS formats
-  --use-dynamic-link      use dynamic linked 3rd party libraries
+  --use-optional-formats  support JPEG, PNG, and EXR formats
+  --use-dynamic-link      use system installed 3rd party libraries
+  --no-texassemble        do not build texassemble
   --debug                 enable debug build
   --test                  build and run tests
+  --generator <name>      specify a build system e.g. Ninja
   --universal             build universal binary for macOS
-  --no-texassemble        do not build texassemble
 
   Examples:
-    build.sh
-      -> generates libtexconv.so in the project root (Texconv-Custom-DLL/)
-    build.sh --build-as-exe
+    build.cmd
+      -> generates libtexconv in the project root (Texconv-Custom-DLL/)
+    build.cmd --build-as-exe
       -> generates texconv and texassemble in the project root.
-    build.sh --use-optional-formats
-      -> generates libtexconv.so with JPEG, PNG, and EXR support.
-    build.sh --use-optional-formats --build-as-exe
-      -> generates texconv and texassemble with JPEG, PNG, EXR support.
+    build.cmd --use-optional-formats
+      -> generates libtexconv with JPEG, PNG, and EXR support.
+    build.cmd --build-as-exe --generator "Unix Makefiles"
+      -> generates texconv and texassemble with make.
 ```

--- a/docs/Build-on-Windows.md
+++ b/docs/Build-on-Windows.md
@@ -10,8 +10,9 @@
 > [!note]
 > It is recommended to use Visual Studio as a build system because it can install Windows SDK and find fxc without editing environment variables. Also, MinGW's fxc ([mingw-w64-fxc2](https://packages.msys2.org/base/mingw-w64-fxc2)) does not work in this project.
 
-## 1. Get DirectXTex
-Move to `.\Texconv-Custom-DLL` and run `git submodule update --init --recursive`.
+## 1. Get submodules
+
+Move to `.\Texconv-Custom-DLL` and get submodules.
 
 ```
 git submodule update --init --recursive
@@ -19,10 +20,10 @@ git submodule update --init --recursive
 
 ## 2. Build DLL
 
-You can build `texconv.dll` with `.\batch_files\build.bat`.
+You can build `texconv.dll` with `.\build.cmd`.
 
 ```
-.\batch_files\build.bat --use-optional-formats
+.\build.cmd --use-optional-formats
 ```
 
 It generates `texconv.dll` in `Texconv-Custom-DLL\`.  
@@ -32,7 +33,7 @@ It generates `texconv.dll` in `Texconv-Custom-DLL\`.
 If you want executables, add `--build-as-exe` to options.
 
 ```
-.\batch_files\build.bat --use-optional-formats --build-as-exe
+.\build.cmd --use-optional-formats --build-as-exe
 ```
 
 It generates `texconv.exe` and `texassemble.exe` in `.\Texconv-Custom-DLL\`.  
@@ -40,25 +41,28 @@ You can use the built binaries on the command prompt. (e.g. `.\texconv.exe -ft t
 
 ## 4. More options
 
-There are more options for `build.bat`.
+There are more options for `build.cmd`.
 
 ```console
-Usage: build.bat <options>
-  --build-as-exe    build texconv and texassemble as executables
-  --runtime-dll     use dynamic linked vcruntime
-  --debug           enable debug build
-  --test            build and run tests
-  --no-wic          disable WIC supported formats (JPEG, PNG, etc.)
-  --no-texassemble  do not build texassemble
-  --use-exr         support EXR format
-  --use-optional-formats  same as --use-exr
-  --generator       one of CMake Generators e.g. Visual Studio 17 2022
+Usage: build.cmd [options]
+  --build-as-exe          build texconv and texassemble as executables
+  --use-optional-formats  support EXR format
+  --use-dynamic-link      use system installed OpenEXR
+  --no-texassemble        do not build texassemble
+  --debug                 enable debug build
+  --test                  build and run tests
+  --generator <name>      specify a build system e.g. Ninja
+  --runtime-dll           use dynamic linked vcruntime
+  --no-wic                disable WIC supported formats (JPEG, PNG, etc.)
+  --use-exr               same as --use-optional-formats
 
   Examples:
-    build.bat
+    build.cmd
       generates texconv.dll in the project root (Texconv-Custom-DLL/)
-    build.bat --build-as-exe
+    build.cmd --build-as-exe
       generates texconv.exe and texassemble.exe in the project root.
-    build.bat --build-as-exe --generator "MinGW Makefiles"
+    build.cmd --use-optional-formats
+      generates texconv.dll with EXR support
+    build.cmd --build-as-exe --generator "MinGW Makefiles"
       builds texconv.exe with MinGW's make
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,23 +47,26 @@ See here if you want to know how to use texconv.
 
 ## Building
 
-### Windows
+### Wrapper script
 
-There is a document for Windows users.  
-[Building Workflow for Windows](./Build-on-Windows.md)  
+We provide a CMake wrapper [`./build.cmd`](../build.cmd) to build texconv with a single command.
+See the following pages for the details.  
 
-### Linux and Mac
-
-There is a document for Linux and Mac users.  
-[Building Workflow for Linux and MacOS](./Build-on-Unix.md)  
+- [Building Workflow for Windows](./Build-on-Windows.md)
+- [Building Workflow for Linux and MacOS](./Build-on-Unix.md)
 
 ### Docker
 
-Linux users can use docker files to build the binary.  
-See the files for the details.  
+Linux users can use docker to build the binaries.
+See the docker files for the details.  
 
 - [Dockerfile_Ubuntu](../Dockerfile_Ubuntu): Build texconv with GCC and glibc on Ubuntu
 - [Dockerfile_Alpine](../Dockerfile_Alpine): Build texconv with GCC and musl on Alpine Linux
+
+### CMake
+
+Of course, you can run CMake commands yourself.
+See [CMake-Options.md](./CMake-Options.md) for available options.
 
 ## Licenses
 


### PR DESCRIPTION
Added a wrapper script: `build.cmd`.
It calls `./batch_files/build.bat` on Windows, and calls `./shell_scripts/build.sh` on Linux/macOS.
You can use the same commands on all platforms to build texconv.

```
./build.cmd --use-optional-formats
./build.cmd --use-optional-formats --build-as-exe
```