### PR TITLE
add a shell script to check required glibc versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,9 @@ jobs:
       - name: build texconv
         run: |
           docker build --build-arg TEST=true -t texconv -f Dockerfile_Ubuntu ./
+
+      - name: check glibc compatibility
+        run: |
+          docker run --name texconv texconv
+          docker cp texconv:/Texconv-Custom-DLL/libtexconv.so .
+          ./scripts/check_glibc_compatibility.sh ./libtexconv.so

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,6 @@ out
 !batch_files/*.bat
 *.sh
 !shell_scripts/*.sh
+!scripts/*.bat
+!scripts/*.sh
 memo*

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ Each zip file has a DLL and executables. The executables don't refer the DLL.
 
 -   `TexconvCustomDLL*-Windows.zip` is for Windows.
 -   `TexconvCustomDLL*-macOS.tar.xz` is for macOS (10.15 or later).
--   `TexconvCustomDLL*-Linux.tar.xz` is for Linux with GLIBC 2.27+ and GLIBCXX 3.4.26+.
+-   `TexconvCustomDLL*-Linux.tar.xz` is for Linux with GLIBC 2.29+ and GLIBCXX 3.4.26+.
 
 > [!Note]
 > The linux build only supports distributions using GLIBC.  

--- a/scripts/check_glibc_compatibility.sh
+++ b/scripts/check_glibc_compatibility.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Checks required versions of GLIBC and GLIBCXX.
+# Usage:
+#   ./check_glibc_compatibility.sh <file>
+
+glibc_deps=$(objdump -T $1 | grep GLIBC_ | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu)
+glibcxx_deps=$(objdump -T $1 | grep GLIBCXX_ | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | sort -Vu)
+IFS=''
+if [ "${glibc_deps}" != "" ]; then
+    echo Required GLIBC versions;
+    echo $glibc_deps
+fi
+if [ "${glibcxx_deps}" != "" ]; then
+    echo Required GLIBCXX versions;
+    echo $glibcxx_deps
+fi
+if [ "${glibc_deps}" == "" ] && [ "${glibcxx_deps}" == "" ]; then
+    echo No GLIBC dependencies.
+fi


### PR DESCRIPTION
CI workflow now shows required glibc versions of Linux binaries.
The current version of libtexconv requires GLIBC 2.29 and GLIBCXX 3.4.26.

```console
> ./scripts/check_glibc_compatibility.sh ./libtexconv.so
Required GLIBC versions
2.2.5
2.3
2.3.4
2.4
2.7
2.11
2.14
2.16
2.27
2.29
Required GLIBCXX versions
3.4
3.4.9
3.4.11
3.4.14
3.4.15
3.4.17
3.4.20
3.4.21
3.4.22
3.4.26
```